### PR TITLE
Add handling for nested maps in yaml/json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ If the file `yourapp.yml` has the following content:
         "listen": "0.0.0.0",
         "enabled": true
       }
+    prod:
+      _: awesome value # the special _ key gets dropped and allows you to set a value for 'prod' and still nest stuff under it
+      redis:
+        port: 6380 # This gets flattened down to 'prod/redis/port' before getting sent along
 
 Then `constancy push` will attempt to create and/or update the following keys
 with the corresponding content from `yourapp.yml`:

--- a/lib/constancy/sync_target.rb
+++ b/lib/constancy/sync_target.rb
@@ -98,7 +98,7 @@ class Constancy
 
       when :file
         if File.exist?(self.base_path)
-          @local_items = YAML.load_file(self.base_path)
+          @local_items = flatten_hash(nil, YAML.load_file(self.base_path))
         end
       end
 
@@ -121,6 +121,27 @@ class Constancy
 
     def diff(mode)
       Constancy::Diff.new(target: self, local: self.local_items, remote: self.remote_items, mode: mode)
+    end
+
+    private def flatten_hash(prefix, hash)
+      new_hash = {}
+
+      hash.each do |k, v|
+        if k == '_' && !prefix.nil?
+          new_key = prefix
+        else
+          new_key = [prefix, k].compact.join('/')
+        end
+
+        case v
+        when Hash
+          new_hash.merge!(flatten_hash(new_key, v))
+        else
+          new_hash[new_key] = v
+        end
+      end
+
+      new_hash
     end
   end
 end

--- a/spec/fixtures/nested_hashes.yml
+++ b/spec/fixtures/nested_hashes.yml
@@ -1,0 +1,7 @@
+---
+one_key: foo
+nested_hash:
+  two_key: bar
+  nested_hash:
+    _: wat
+    three_key: baz

--- a/spec/lib/constancy/sync_target_spec.rb
+++ b/spec/lib/constancy/sync_target_spec.rb
@@ -1,0 +1,31 @@
+# This software is public domain. No rights are reserved. See LICENSE for more information.
+
+require 'spec_helper'
+
+RSpec.describe Constancy::SyncTarget do
+  describe '#local_items' do
+    context 'using a yml file with deeply nested hashes' do
+      let(:tgt) {
+        Constancy::SyncTarget.new(
+          base_dir: FIXTURE_DIR,
+          config: {
+            'type'   => 'file',
+            'path'   => "nested_hashes.yml",
+            'prefix' => 'config/nested'
+          },
+          imperium_config: Imperium::Configuration.new,
+        )
+      }
+
+      it 'must flatten the nested hashes' do
+        items = tgt.local_items
+        expect(items.values).to all be_a String
+
+        expect(items).to include({'one_key' => 'foo'})
+        expect(items).to include({'nested_hash/two_key' => 'bar'})
+        expect(items).to include({'nested_hash/nested_hash/three_key' => 'baz'})
+        expect(items).to include({'nested_hash/nested_hash' => 'wat'})
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require 'constancy'
 
+SPEC_DIR = File.dirname(__FILE__)
+FIXTURE_DIR = File.join(SPEC_DIR, 'fixtures')
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.color = true


### PR DESCRIPTION
This will allow for really DRY config files where a lot of keys are
being set with the same initial components.