### PR TITLE
skip confirmation prompt for push/pull (--yes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+* Allow skipping the confirmation prompt for the `push` and `pull` commands by
+  passing `--yes`
+
 ## 0.3.1 (March 9, 2019)
 
 * Support more flexible key specification in file targets (@tpickett66) (#4)

--- a/lib/constancy/cli.rb
+++ b/lib/constancy/cli.rb
@@ -67,6 +67,12 @@ General options:
 Options for 'check' command:
   --pull       Perform dry run in pull mode
 
+Options for 'pull' command:
+  --yes        Skip confirmation prompt
+
+Options for 'push' command:
+  --yes        Skip confirmation prompt
+
 USAGE
         exit 1
       end
@@ -124,8 +130,8 @@ USAGE
         when :command
           case self.command
           when 'check'      then Constancy::CLI::CheckCommand.run(self.extra_args)
-          when 'push'       then Constancy::CLI::PushCommand.run
-          when 'pull'       then Constancy::CLI::PullCommand.run
+          when 'push'       then Constancy::CLI::PushCommand.run(self.extra_args)
+          when 'pull'       then Constancy::CLI::PullCommand.run(self.extra_args)
           when 'config'     then Constancy::CLI::ConfigCommand.run
           when 'targets'    then Constancy::CLI::TargetsCommand.run
           when nil          then self.print_usage

--- a/lib/constancy/cli/pull_command.rb
+++ b/lib/constancy/cli/pull_command.rb
@@ -4,7 +4,7 @@ class Constancy
   class CLI
     class PullCommand
       class << self
-        def run
+        def run(args)
           Constancy::CLI.configure
           STDOUT.sync = true
 
@@ -22,7 +22,7 @@ class Constancy
             puts
             puts "Do you want to pull these changes?"
             print "  Enter '" + "yes".bold + "' to continue: "
-            answer = gets.chomp
+            answer = args.include?('--yes') ? 'yes' : gets.chomp
 
             if answer.downcase != "yes"
               puts

--- a/lib/constancy/cli/push_command.rb
+++ b/lib/constancy/cli/push_command.rb
@@ -4,7 +4,7 @@ class Constancy
   class CLI
     class PushCommand
       class << self
-        def run
+        def run(args)
           Constancy::CLI.configure
           STDOUT.sync = true
 
@@ -22,7 +22,7 @@ class Constancy
             puts
             puts "Do you want to push these changes?"
             print "  Enter '" + "yes".bold + "' to continue: "
-            answer = gets.chomp
+            answer = args.include?('--yes') ? 'yes' : gets.chomp
 
             if answer.downcase != "yes"
               puts


### PR DESCRIPTION
this makes constancy more friendly to non-interactive sessions like in a script

    constancy push --yes